### PR TITLE
Card eval

### DIFF
--- a/equity_hu.py
+++ b/equity_hu.py
@@ -69,6 +69,6 @@ def equity_hu_exact(hero_hole: List[Card], villain_hole: List[Card], board_parti
     if Total == 0:
         equity = 0.0
     else: 
-        (Wins + 0.5 * Ties) / Total
+        equity = (Wins + 0.5 * Ties) / Total
 
     return {"equity": equity, "wins": Wins, "ties": Ties, "total": Total}

--- a/equity_hu.py
+++ b/equity_hu.py
@@ -1,0 +1,74 @@
+# 2 player headsup equity calculations
+# 1 or 2 unknown cards (turn and river)
+
+#hero_hole and villain_hole
+
+from typing import List, Tuple, Dict
+from itertools import combinations
+import math
+
+from cards import make_deck, Card
+from hand_rank7 import rank7
+
+def _validate_inputs(hero_hole: List[Card], villain_hole: List[Card], board_partial: List[Card]):
+    if len(hero_hole) != 2 or len(villain_hole) != 2:
+        raise ValueError("Both hero and villain must have exactly 2 hole cards.")
+    if len(board_partial) > 5:
+        raise ValueError("Board can have at most 5 cards.")
+    all_cards = hero_hole + villain_hole + board_partial
+    if len(set(all_cards)) != len(all_cards):
+        raise ValueError("All cards must be distinct.")
+    
+def _choose(n: int, k: int) -> int:
+    if k < 0 or k > n:
+        return 0
+    return math.comb(n, k)
+
+def enumerate_runouts(hero_hole: List[Card], villain_hole: List[Card], board_partial: List[Card], *, allow_large: bool = False,) -> Dict[str, int]:
+    #find how many cards still unknown in the board
+    # build remaining deck
+    # enumerate runouts for the remaining cards
+    # score the runouts
+    # return Win/ties/total count (equity is expected share of the pot, and ties are half)
+    # equity is (wins + 0.5 * ties) / total
+    _validate_inputs(hero_hole, villain_hole, board_partial)
+
+    need = 5 - len(board_partial)
+    if need < 0:
+        raise ValueError("Board cannot have more than 5 cards.")
+    if need > 2 and not allow_large:
+        raise ValueError("Cannot enumerate runouts with more than 2 unknown cards.")
+    
+    used = hero_hole + villain_hole + board_partial
+    deck = make_deck(exclude=used)
+
+    #counts
+    wins = ties = total = 0
+
+    #enumerate runouts
+    for drawn in combinations(deck, need):
+        full_board = board_partial + list(drawn)
+
+        hero_best = rank7(hero_hole + full_board)
+        villain_best = rank7(villain_hole + full_board)
+
+        if hero_best > villain_best:
+            wins += 1
+        elif hero_best == villain_best:
+            ties += 1
+        total += 1
+
+    return {"wins": wins, "ties": ties, "total": total}
+
+def equity_hu_exact(hero_hole: List[Card], villain_hole: List[Card], board_partial: List[Card], *, allow_large: bool = False) -> Dict[str, float]:
+    #calculate exact equity for 1v1 poker
+    counts = enumerate_runouts(hero_hole, villain_hole, board_partial, allow_large=allow_large)
+    
+    Wins, Ties, Total = counts["wins"], counts["ties"], counts["total"]
+
+    if Total == 0:
+        equity = 0.0
+    else: 
+        (Wins + 0.5 * Ties) / Total
+
+    return {"equity": equity, "wins": Wins, "ties": Ties, "total": Total}

--- a/hand_rank7.py
+++ b/hand_rank7.py
@@ -1,0 +1,27 @@
+# reuses hand_rank5.py but enumerates C(7,5) = 21 possibilities of five-card subsets
+# could optimize with a direct 7-card evaluator
+
+from itertools import combinations
+from typing import List, Tuple
+from hand_rank5 import rank5
+
+Card = Tuple[int, str]
+
+def rank7(cards7: List[Card]) -> tuple:
+    #get best 5-card poker hand available from 7 cards
+
+    if len(cards7) != 7:
+        raise ValueError("Expected exactly 7 cards")
+    
+    #check that all cards are distinct
+    if len(set(cards7)) != 7:
+        raise ValueError("Cards must be distinct")
+    
+    best = None
+
+    for five in combinations(cards7, 5):
+        r = rank5(list(five))
+        if best is None or r > best:
+            best = r
+
+    return best

--- a/ranges.py
+++ b/ranges.py
@@ -15,14 +15,14 @@ def _all_nonpair_combos(vhi: int, vlo: int, suited_flag: Optional[bool]) -> List
     #suited_flag is True for suited only, False for offsuit only, None for both
     out: List[Tuple[Card, Card]] = []
     if suited_flag is None:
-        if suited_flag is None:
-            out.extend(_all_nonpair_combos(vhi, vlo, True))
-            out.extend(_all_nonpair_combos(vhi, vlo, False))
-            return out
-        if suited_flag:
-            for s in SUITS:
-                out.append(((vhi, s), (vlo, s)))
-            return out
+        out.extend(_all_nonpair_combos(vhi, vlo, True))
+        out.extend(_all_nonpair_combos(vhi, vlo, False))
+        return out
+
+    if suited_flag:
+        for s in SUITS:
+            out.append(((vhi, s), (vlo, s)))
+        return out
     #offsuit
     for s1 in SUITS:
         for s2 in SUITS:
@@ -110,11 +110,11 @@ def range_to_combos(range_list: List[str], exclude: Iterable[Card] = ()) -> List
                     combo = (c2, c1)
                 else:
                     combo = (c1, c2)
-                combos.append(combo)
+                out.append(combo)
 
     seen = set()
     unique: List[Tuple[Card, Card]] = []
-    for combo in combos:
+    for combo in out:
         if combo not in seen: 
             seen.add(combo)
             unique.append(combo)

--- a/ranges.py
+++ b/ranges.py
@@ -1,0 +1,74 @@
+from typing import Iterable, List, Tuple, Optional
+from cards import RANKS, SUITS, RANK_TO_VAL, VAL_TO_RANK, Card
+
+def _all_pair_combos(v: int) -> List[Tuple[Card, Card]]:
+    # v is rank, should be 6 suit combos for pocket pair
+    out: List[Tuple[Card, Card]] = []
+    suits = list(SUITS)
+    for i in range(len(suits)):
+        for j in range(i + 1, len(suits)):
+            out.append(((v, suits[i]), (v, suits[j])))
+
+    return out # 6 combos
+
+def _all_nonpair_combos(vhi: int, vlo: int, suited_flag: Optional[bool]) -> List[Tuple[Card, Card]]:
+    #suited_flag is True for suited only, False for offsuit only, None for both
+    out: List[Tuple[Card, Card]] = []
+    if suited_flag is None:
+        if suited_flag is None:
+            out.extend(_all_nonpair_combos(vhi, vlo, True))
+            out.extend(_all_nonpair_combos(vhi, vlo, False))
+            return out
+        if suited_flag:
+            for s in SUITS:
+                out.append(((vhi, s), (vlo, s)))
+            return out
+    #offsuit
+    for s1 in SUITS:
+        for s2 in SUITS:
+            if s1 == s2:
+                continue
+            out.append(((vhi, s1), (vlo, s2)))
+    return out
+
+def _expand_token(token: str) -> List[Tuple[str, int, int, Optional[bool]]]:
+    # expand single token into list of (kind, vhi, vlo, suited_flag) where kind is either pair or nonpair
+    t = token.strip()
+    if not t or len(t) < 2:
+        return []
+    plus = t.endswith("+")
+    if plus:
+        t = t[:-1]
+
+    suited_flag: Optional[bool] = None
+    if t.endswith("s"):
+        suited_flag = True
+        t = t[:-1]
+    elif t.endswith("o"):
+        suited_flag = False
+        t = t[:-1]
+    
+    if len(t) != 2:
+        return []
+    
+    r1, r2 = t[0].upper(), t[1].upper()
+    if r1 not in RANK_TO_VAL or r2 not in RANK_TO_VAL:
+        return []
+    
+    v1, v2 = RANK_TO_VAL[r1], RANK_TO_VAL[r2]
+
+    if v2 > v1:
+        v1, v2 = v2, v1
+
+    if v1 == v2:
+        if plus:
+            return [("pair", v, 0, None) for v in range(v1, 15)]
+        else:
+            return [("pair", v1, 0, None)]
+    
+    if plus:
+        lows = list(range(v2, v1))
+    else:
+        lows = [v2]
+    return [("nonpair", v1, lo, suited_flag) for lo in lows]
+

--- a/test_equity_hu.py
+++ b/test_equity_hu.py
@@ -1,0 +1,77 @@
+import math
+import pytest
+from cards import parse_card
+from equity_hu import enumerate_runouts, equity_hu_exact
+
+def H(*ss):
+    """Helper: 'Ah','Td' → [(14,'h'), (10,'d')]"""
+    return [parse_card(s) for s in ss]
+
+# ---------- Full board (need = 0) ----------
+
+def test_full_board_hero_wins():
+    hero = H("As","Kd")
+    vill = H("9h","9d")
+    # Removed the 9♠ from board so villain doesn't make trips
+    board = H("Ah","8s","2c","7d","3h")  # hero: pair A; villain: pair 9 → hero wins
+    res = equity_hu_exact(hero, vill, board)
+    assert res["total"] == 1
+    assert res["equity"] == 1.0
+    assert res["wins"] == 1 and res["ties"] == 0
+
+def test_full_board_tie():
+    hero = H("2c","3d")
+    vill = H("4s","5c")
+    board = H("Ah","Kh","Qh","Jh","Th")  # royal flush on board → everyone chops
+    res = equity_hu_exact(hero, vill, board)
+    assert res["total"] == 1
+    assert res["equity"] == 0.5
+    assert res["wins"] == 0 and res["ties"] == 1
+
+def test_full_board_hero_loses():
+    hero = H("As","Kd")
+    vill = H("Kh","Qh")
+    board = H("Ah","9h","7d","2s","3h")  # villain makes a heart flush
+    res = equity_hu_exact(hero, vill, board)
+    assert res["total"] == 1
+    assert res["equity"] == 0.0
+    assert res["wins"] == 0 and res["ties"] == 0
+
+# ---------- River-only unknown (need = 1) ----------
+
+def test_river_only_enumeration_count_and_equity_range():
+    # Turn known (4 cards), river unknown → exactly 44 runouts.
+    hero = H("Ah","Qh")                 # nut heart draw + two broadways
+    vill = H("Jd","9d")                 # top pair J with 9 kicker on this board
+    board = H("Jh","7c","2h","9s")      # two hearts on board, so any heart river makes 5 hearts
+    res = equity_hu_exact(hero, vill, board)
+    assert res["total"] == 44
+
+    # Exactly 9 heart rivers exist, but 9♥ gives villain a full house (9♦+9♠+9♥ with J♦+J♥),
+    # which beats our flush. So hero wins only on 8 rivers.
+    # Equity = 8 / 44 exactly.
+    assert res["equity"] == pytest.approx(8/44, rel=1e-12)
+
+# ---------- Turn + River unknown (need = 2) ----------
+
+def test_turn_river_enumeration_count_and_equity_range():
+    # Flop known (3 cards), need=2 → combinations should be C(45, 2) = 990.
+    hero = H("Ah","Qh")
+    vill = H("Jd","9d")
+    board = H("Jh","7c","2h")           # flop only
+    res_counts = enumerate_runouts(hero, vill, board)
+    assert res_counts["total"] == math.comb(45, 2)  # 990
+
+    res = equity_hu_exact(hero, vill, board)
+    # Equity range sanity (again, deliberately loose so tests are stable)
+    assert 0.30 <= res["equity"] <= 0.60
+
+# ---------- Guard rails (too many unknowns) ----------
+
+def test_refuse_large_enumeration_by_default():
+    # Preflop (need=5) should raise unless allow_large=True.
+    hero = H("As","Kd")
+    vill = H("Qh","Qs")
+    board = []
+    with pytest.raises(ValueError):
+        enumerate_runouts(hero, vill, board)  # need=5 → too big by default

--- a/test_ranges.py
+++ b/test_ranges.py
@@ -1,0 +1,48 @@
+import pytest
+from cards import parse_card, VAL_TO_RANK, card_str
+from ranges import parse_range_tokens, range_to_combos
+
+def C(*ss):
+    return [parse_card(s) for s in ss]
+
+def test_token_validation_and_normalization():
+    ok = parse_range_tokens(["22", "TT+", "AQ", "AQs", "AQo", "A9s+", "KTs+", "AQ+"])
+    assert ok == ["22","TT+","AQ","AQs","AQo","A9s+","KTs+","AQ+"]
+
+    # bad tokens
+    with pytest.raises(ValueError):
+        parse_range_tokens(["10h"])   # we require "T" not "10"
+    with pytest.raises(ValueError):
+        parse_range_tokens(["AQQ"])   # malformed
+    with pytest.raises(ValueError):
+        parse_range_tokens(["A2x"])   # bad suit flag
+
+def test_combo_counts_no_blockers():
+    # pairs
+    assert len(range_to_combos(["AA"])) == 6
+    # suited / offsuit / both
+    assert len(range_to_combos(["AQs"])) == 4
+    assert len(range_to_combos(["AQo"])) == 12
+    assert len(range_to_combos(["AQ"])) == 16
+    # plus ranges
+    assert len(range_to_combos(["22+"])) == 13 * 6   # 13 pocket pairs * 6 = 78
+    assert len(range_to_combos(["A9s+"])) == 5 * 4   # A9s,ATs,AJs,AQs,AKs → 5 * 4 = 20
+    assert len(range_to_combos(["KTs+"])) == 3 * 4   # KTs,KJs,KQs → 3 * 4 = 12
+    assert len(range_to_combos(["AQ+"])) == (4+12) + (4+12)  # AQ + AK (both s/o) = 32
+
+def test_dedup_overlapping_tokens():
+    # "AQ" already includes AQs, so "AQ" + "AQs" should still yield 16 not 20
+    assert len(range_to_combos(["AQ","AQs"])) == 16
+
+def test_blockers_remove_specific_combos():
+    # AQs has 4 combos: AsQs, AhQh, AdQd, AcQc
+    # Excluding As and Qh leaves AdQd and AcQc (2 combos)
+    excl = C("As","Qh")
+    combos = range_to_combos(["AQs"], exclude=excl)
+    assert len(combos) == 2
+    # ensure the remaining combos are the suited diamonds and clubs
+    as_strs = set(
+    card_str((r1, s1)) + card_str((r2, s2))
+    for ((r1, s1), (r2, s2)) in combos
+    )
+    assert "AdQd" in as_strs and "AcQc" in as_strs

--- a/test_rank7.py
+++ b/test_rank7.py
@@ -1,0 +1,55 @@
+import pytest
+from cards import parse_card
+from hand_rank7 import rank7
+
+def H(*ss):
+    """Helper: parse strings like 'Ah','Td' into card tuples."""
+    return [parse_card(s) for s in ss]
+
+def test_requires_exactly_seven_and_no_duplicates():
+    # wrong sizes
+    with pytest.raises(ValueError):
+        rank7(H("Ah","Kh","Qh","Jh","Th","9h"))  # 6 cards
+    with pytest.raises(ValueError):
+        rank7(H("Ah","Kh","Qh","Jh","Th","9h","8h","7h"))  # 8 cards
+    # duplicates
+    with pytest.raises(ValueError):
+        rank7(H("Ah","Ah","Qh","Jh","Th","9h","8h"))
+
+def test_royal_flush_on_board_is_detected():
+    # Board: royal flush in hearts, Hole: irrelevant low cards
+    cards = H("Ah","Kh","Qh","Jh","Th","2c","3d")
+    r = rank7(cards)
+    # Straight flush with high card Ace (14) -> (8, 14)
+    assert r[0] == 8 and r[1] == 14
+
+def test_flush_improves_with_hole_over_board():
+    # Board has a heart flush A,K,8,4,2; hole adds Qh which should replace 2h
+    cards = H("Ah","Kh","8h","4h","2h","Qh","9c")
+    r = rank7(cards)
+    # Best flush should be A,K,Q,8,4
+    assert r[0] == 5 and r[1:] == (14, 13, 12, 8, 4)
+
+def test_trips_on_board_becomes_full_house_with_hole_pair():
+    # Board: 9 9 9 5 2; Hole: 5 A  -> Full house 9 over 5
+    cards = H("9h","9d","9s","5c","2d","5s","Ah")
+    r = rank7(cards)
+    assert r[0] == 6 and r[1:] == (9, 5)
+
+def test_straight_uses_hole_card():
+    # Board: 5 6 7 8 K (no straight by itself)
+    # Hole adds 9 to make a 9-high straight (5-9)
+    cards = H("5c","6d","7h","8s","Kc","9d","2h")
+    r = rank7(cards)
+    assert r[0] == 4 and r[1] == 9
+
+def test_category_ordering_against_another_hand():
+    # Hand A: strong flush (should beat two pair)
+    handA = H("Ah","Kh","Qh","4h","2h","9c","9d")  # flush hearts A,K,Q,4,2
+    # Hand B: at best two pair K and 9 (no flush/straight)
+    handB = H("Kd","Ks","9h","9s","3c","2d","5s")
+    rA = rank7(handA)
+    rB = rank7(handB)
+    assert rA[0] == 5          # flush
+    assert rB[0] == 2          # two pair
+    assert rA > rB


### PR DESCRIPTION
This pull request introduces a new set of modules for poker hand evaluation and range handling, focusing on heads-up equity calculations, hand ranking, and range parsing. It also adds comprehensive tests for each feature to ensure correctness and robustness. The main changes are grouped below by theme:

**Heads-up equity calculation:**

* Added `equity_hu.py` with functions to enumerate possible board runouts and compute exact heads-up equity for two players, supporting up to two unknown board cards and robust input validation.

**Hand ranking:**

* Introduced `hand_rank7.py`, implementing a 7-card hand evaluator by checking all 5-card subsets using `rank5`, with error handling for invalid input.

**Range parsing and combo generation:**

* Added `ranges.py`, providing utilities to parse poker hand range tokens (e.g., "AQs+", "TT+"), validate them, and expand them into all possible card combinations, supporting blockers and deduplication.

**Testing:**

* Created `test_equity_hu.py` to verify heads-up equity calculations for various board states, edge cases, and input validation.
* Added `test_rank7.py` to test 7-card hand ranking logic, including handling of board flushes, full houses, straights, and comparison between hands.
* Developed `test_ranges.py` to validate range token parsing, combo generation, deduplication, and blocker functionality.